### PR TITLE
Develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ log = "0.4"
 toml = "0.5"
 url = "2.2.0"
 heck = "0.3"
+tempfile = "3.2"
 handlebars = { version = "3.5", optional = true }
 clap = { version = "2.33", optional = true }
 git2 = { version = "0.13", optional = true }

--- a/examples/directory.rs
+++ b/examples/directory.rs
@@ -2,10 +2,10 @@ use std::{env, path::PathBuf};
 use walkdir::{DirEntry, WalkDir};
 
 fn main() {
-  //   let walker = WalkDir::new("/Users/victor/dev/template").into_iter();
-  //   for entry in walker.filter_entry(|e| !is_venv(e)).filter_map(|e| e.ok()) {
-  //     println!("{}", entry.path().display());
-  //   }
+  let walker = WalkDir::new("/Users/victor/dev/template").into_iter();
+  for _entry in walker.filter_entry(|e| !is_venv(e)).filter_map(|e| e.ok()) {
+    // println!("{}", _entry.path().display());
+  }
 
   match std::fs::canonicalize("src/engine") {
     Ok(p) => println!("Fs can: {}", p.display()),

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -1,8 +1,8 @@
-use project::{git, Cli, Template};
+use project::{Cli, Template};
 
 fn main() {
   let cli = Cli::new();
-  let template = Template::from(cli.args);
+  let _template = Template::from(cli.args);
 
   // match tmplt.generate(&"/Users/victor/dev/pricing") {
   //   Ok(_) => println!("Suuccessful"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,7 +218,7 @@ impl<'a> Cli<'a> {
         // project new <local> <name>
         let path = sub_new.value_of("template").unwrap();
         let name = sub_new.value_of("name").unwrap();
-        self.args = Arguments::new(path, name, None);
+        self.args = Arguments::new(name, path, None);
       }
       // "git" subcommand.
       ("git", Some(sub_git)) => {
@@ -233,7 +233,7 @@ impl<'a> Cli<'a> {
         // project init <repo>
         let path = sub_init.value_of("repo").unwrap();
         // TODO: Add `branch` to arguments.
-        self.args = Arguments::from(path)
+        self.args = Arguments::from(path);
       }
       _ => {
         // Unrecognized command or above subcommands was not used.

--- a/src/engine/handlebars.rs
+++ b/src/engine/handlebars.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use handlebars::{Handlebars, HelperDef};
 
 use crate::template::helpers;

--- a/src/git.rs
+++ b/src/git.rs
@@ -27,11 +27,60 @@ impl GitOptions {
         .unwrap_or(GitReference::DefaultBranch),
     }
   }
+
+  pub fn path(&self) -> &str {
+    self.remote.path()
+  }
+
+  /// Fetch template from a remote path into a `template_dir`.
+  pub fn create(&self, template_dir: &Path) -> CargoResult<String> {
+    crate::git::create(template_dir, self)
+  }
+
+  pub fn branch(&self) -> String {
+    match &self.branch {
+      GitReference::Branch(b) => b.to_owned(),
+      GitReference::DefaultBranch => {
+        self.get_default_branch().expect("Unable to fetch `HEAD`.")
+      }
+      _ => {
+        unreachable!()
+      }
+    }
+  }
+
+  fn get_default_branch(&self) -> Result<String> {
+    let repo = GitRepository::init(self.path())?;
+    let mut git_remote = repo.remote_anonymous(self.remote.as_str())?;
+    git_remote.connect(git2::Direction::Fetch)?;
+    let default_branch = git_remote.default_branch()?;
+    let branch_name = default_branch
+      .as_str()
+      .unwrap_or("refs/heads/master")
+      .replace("refs/heads/", "");
+    Ok(branch_name)
+  }
+
+  /// Initializes a new repository from a given git `branch` into a `project_dir`.
+  pub fn init(
+    &self,
+    project_dir: &Path,
+    branch: &str,
+  ) -> Result<GitRepository> {
+    let mut opt = RepositoryInitOptions::new();
+    opt.bare(false);
+    opt.initial_head(branch);
+
+    Ok(
+      GitRepository::init_opts(project_dir, &opt)
+        .unwrap_or_else(|_| panic!("Couldn't init new repository")),
+    )
+  }
 }
 
-/// Checksout a `GitRemote` into a temporary folder.
-pub fn create(project_dir: &Path, opts: &GitOptions) -> CargoResult<String> {
-  let temp = Builder::new().prefix(project_dir).tempdir()?;
+/// Fetch a `GitRemote` into a `template_dir`.
+pub fn create(template_dir: &Path, opts: &GitOptions) -> CargoResult<String> {
+  let temp = Builder::new().prefix(template_dir).tempdir()?;
   let config = Config::default()?;
   let remote = GitRemote::new(&opts.remote);
 
@@ -73,13 +122,18 @@ pub fn create(project_dir: &Path, opts: &GitOptions) -> CargoResult<String> {
   };
 
   // This clones the remote and handles all the submodules.
-  db.copy_to(rev, project_dir, &config)?;
+  db.copy_to(rev, template_dir, &config)?;
+
+  // Remove the ".git" files.
+  fs::remove_dir_all(template_dir.join(".git"))
+    .unwrap_or_else(|_| panic!("Error cleaning up cloned template"));
+
   Ok(branch_name)
 }
 
 /// Clean up all items in `.git/` folder in a cloned git repo.
-pub fn remove_history(project_dir: &Path) -> Result<()> {
-  fs::remove_dir_all(project_dir.join(".git"))
+pub fn remove_history(template_dir: &Path) -> Result<()> {
+  fs::remove_dir_all(template_dir.join(".git"))
     .unwrap_or_else(|_| panic!("Error cleaning up cloned template"));
 
   Ok(())
@@ -97,9 +151,9 @@ pub fn init(project_dir: &Path, branch: &str) -> Result<GitRepository> {
   )
 }
 
-/// Delete repo.
-pub fn delete_local_repo(project_dir: &Path) -> Result<()> {
-  fs::remove_dir_all(project_dir)
+/// Delete temporary template repo from base `template_dir`.
+pub fn delete_local_repo(template_dir: &Path) -> Result<()> {
+  fs::remove_dir_all(template_dir)
     .unwrap_or_else(|_| panic!("Error cleaning up git repo"));
 
   Ok(())

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,6 +1,6 @@
 use crate::{
   error::{Error, Result},
-  git::{self, GitOptions},
+  git::GitOptions,
   template::config::TemplateConfig,
   util,
 };
@@ -86,7 +86,7 @@ impl Default for ProjectInfo {
 
 /// `TemplateOptions` describes the kind of template we are using,
 /// either a remote template or a local template.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum TemplateOptions {
   /// A local template with the path to the base template directory.
   Local(PathBuf),
@@ -112,7 +112,7 @@ impl TemplateOptions {
     // relative/path/to/template
     match Self::parse_path(path, branch.map(|s| s.to_string())) {
       Ok(opts) => opts,
-      Err(err) => panic!("Error: {}", err),
+      Err(err) => panic!("ERROR: {}", err),
     }
   }
 
@@ -131,8 +131,7 @@ impl TemplateOptions {
         match fs::canonicalize(path) {
           // Relative local file path.
           Ok(p) => Self::Local(p),
-          Err(err) => {
-            eprintln!("does not exist. {}", err);
+          Err(_err) => {
             // Short Git URI.
             Self::parse_path(&format!("https://github.com/{}", path), branch)?
           }
@@ -143,7 +142,17 @@ impl TemplateOptions {
       }
     };
 
+    println!("{:?}", opts);
     Ok(opts)
+  }
+}
+
+impl TemplateOptions {
+  pub fn path(&self) -> &Path {
+    match self {
+      TemplateOptions::Local(p) => p,
+      TemplateOptions::Remote(g) => &Path::new(g.path()),
+    }
   }
 }
 
@@ -155,14 +164,16 @@ impl From<&dyn AsRef<Path>> for TemplateOptions {
 
 impl Default for TemplateOptions {
   fn default() -> Self {
-    Self::Local(env::current_dir().unwrap_or_default())
+    let curr_dir = env::current_dir().unwrap_or_else(|_| ".".into());
+
+    Self::Local(curr_dir)
   }
 }
 
 /// Template & project comes together to load the template from remote or local
 /// path, loads the `"template.toml"` config file, and initializes git for the
 /// new project.
-pub struct TemplateInfo {
+pub struct TemplateMeta {
   #[doc(hidden)]
   template_options: TemplateOptions,
 
@@ -173,43 +184,43 @@ pub struct TemplateInfo {
   project_info: ProjectInfo,
 }
 
-impl TemplateInfo {
+impl TemplateMeta {
   pub fn new(
     project_info: &ProjectInfo,
     template_options: &TemplateOptions,
   ) -> Self {
-    TemplateInfo {
+    println!("\nProjectInfo: {:?}", project_info);
+    println!("TemplateOptions: {:?}\n", template_options);
+
+    // Create new project's directory.
+    fs::create_dir_all(&project_info.path).unwrap();
+
+    if let TemplateOptions::Remote(opts) = template_options {
+      // Download template if it's a remote template.
+      TemplateMeta::load_remote(opts, &template_options.path()).unwrap();
+    }
+
+    TemplateMeta {
+      config: TemplateConfig::new(template_options.path(), &project_info.name),
       template_options: template_options.clone(),
-      config: TemplateConfig::new(&project_info),
       project_info: project_info.clone(),
     }
   }
 
-  pub fn load(&self) -> Result<()> {
-    match &self.template_options {
-      TemplateOptions::Local(local) => {
-        // TODO: Dunno what to do here...
-        println!("Using local template: {}", local.display());
-      }
-      TemplateOptions::Remote(git_opts) => {
-        // Download remote template into project dir.
-        println!("Download repo to a temp file");
-        match git::create(&self.project_info.path, git_opts) {
-          Ok(branch) => {
-            println!("Usint the `{}` branch", branch);
-            git::remove_history(&self.project_info.path)?;
-          }
-          Err(err) => panic!("Could not create template: {}", err),
-        }
-      }
+  fn load_remote(git_opts: &GitOptions, template_dir: &Path) -> Result<()> {
+    match git_opts.create(template_dir) {
+      Ok(_branch) => {}
+      Err(err) => panic!("Could not create template: {}", err),
     }
     Ok(())
   }
 }
 
-impl Default for TemplateInfo {
-  fn default() -> TemplateInfo {
-    TemplateInfo {
+impl TemplateMeta {}
+
+impl Default for TemplateMeta {
+  fn default() -> TemplateMeta {
+    TemplateMeta {
       template_options: TemplateOptions::default(),
       config: TemplateConfig::default(),
       project_info: ProjectInfo::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ mod error;
 pub mod git;
 mod info;
 mod render;
-mod substitution;
 pub mod template;
 pub(crate) mod util;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,7 +5,10 @@ use std::path::Path;
 pub trait Renderer {
   fn render(writer: dyn std::io::Write) -> Result<()>;
 
-  fn generate(template: Template, target_path: &dyn AsRef<Path>) -> Result<()> {
+  fn generate(
+    _template: Template,
+    _target_path: &dyn AsRef<Path>,
+  ) -> Result<()> {
     Ok(())
   }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use crate::{
   cli::{Arguments, Cli},
-  info::TemplateInfo,
+  info::TemplateMeta,
 };
 
 pub(crate) mod config;
@@ -15,13 +15,13 @@ pub(crate) mod parser;
 
 /// Template builds and generates the project from a given template.
 pub struct Template {
-  template: TemplateInfo,
+  template: TemplateMeta,
 }
 
 impl From<Arguments> for Template {
   fn from(args: Arguments) -> Template {
     Template {
-      template: TemplateInfo::new(&args.project, &args.template),
+      template: TemplateMeta::new(&args.project, &args.template),
     }
   }
 }
@@ -33,7 +33,7 @@ impl From<Cli<'_>> for Template {
 }
 
 impl Template {
-  fn new(template_info: TemplateInfo) -> Template {
+  fn new(template_info: TemplateMeta) -> Template {
     Template {
       template: template_info,
     }
@@ -43,7 +43,7 @@ impl Template {
 impl Default for Template {
   fn default() -> Template {
     Template {
-      template: TemplateInfo::default(),
+      template: TemplateMeta::default(),
     }
   }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,7 @@
-use crate::cli::{Arguments, Cli};
+use crate::{
+  cli::{Arguments, Cli},
+  info::TemplateInfo,
+};
 
 pub(crate) mod config;
 #[cfg(feature = "git")]
@@ -8,18 +11,40 @@ pub mod git;
 pub mod guidon;
 #[cfg(feature = "hbs")]
 pub(crate) mod helpers;
+pub(crate) mod parser;
 
-pub struct Template {}
+/// Template builds and generates the project from a given template.
+pub struct Template {
+  template: TemplateInfo,
+}
 
 impl From<Arguments> for Template {
   fn from(args: Arguments) -> Template {
-    Template {}
+    Template {
+      template: TemplateInfo::new(&args.project, &args.template),
+    }
   }
 }
 
 impl From<Cli<'_>> for Template {
   fn from(cli: Cli) -> Template {
     Self::from(cli.args)
+  }
+}
+
+impl Template {
+  fn new(template_info: TemplateInfo) -> Template {
+    Template {
+      template: template_info,
+    }
+  }
+}
+
+impl Default for Template {
+  fn default() -> Template {
+    Template {
+      template: TemplateInfo::default(),
+    }
   }
 }
 

--- a/src/template/config.rs
+++ b/src/template/config.rs
@@ -1,15 +1,14 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::str::FromStr;
 
 use serde::Deserialize;
 
-use crate::error::{Error, Result};
-use crate::util;
-use crate::{engine::Engine, substitution};
+use crate::{
+  engine::Engine, error::Result, info::ProjectInfo, template::parser,
+};
 
 /// Default template file containing variable template substitution.
-pub const TEMPLATE_FILE: &str = "template.toml";
+pub(crate) const TEMPLATE_FILE: &str = "template.toml";
 
 #[derive(Deserialize)]
 pub struct TemplateConfig {
@@ -24,20 +23,26 @@ pub struct TemplateConfig {
 }
 
 impl TemplateConfig {
-  /// Create a new `TemplateConfig` from `config::TEMPLATE_FILE`.
-  pub fn new(path: &dyn AsRef<Path>) -> Self {
-    match Self::parse(&path.as_ref().join(TEMPLATE_FILE)) {
+  /// Create & parse the `"template.toml"` file in the project base directory.
+  pub fn new(project_info: &ProjectInfo) -> TemplateConfig {
+    match Self::parse(&project_info.path, &project_info.name) {
       Ok(config) => config,
-      Err(_) => TemplateConfig::default(),
+      Err(err) => {
+        eprintln!(
+          "Could not parse template file. Using default configurations."
+        );
+        TemplateConfig::default()
+      }
     }
   }
 
   /// Parse a given `template.toml` file as substitute all default variables.
   ///
   /// Return as a `Result<TemplateConfig>` for successful and parse failure.
-  pub(crate) fn parse(path: &dyn AsRef<Path>) -> Result<Self> {
+  fn parse(project_dir: &dyn AsRef<Path>, project_name: &str) -> Result<Self> {
+    let template_path = project_dir.as_ref().join(TEMPLATE_FILE);
     // Parsed template string.
-    let parsed = substitution::parse_template_file(path, util::filename(path))?;
+    let parsed = parser::parse_template_file(&template_path, project_name)?;
 
     // Deserialize the `template.toml` file into `TemplateConfig`.
     let mut config: TemplateConfig = toml::from_str(&parsed)?;
@@ -52,23 +57,6 @@ impl TemplateConfig {
 
     // Return the parsed configuration.
     Ok(config)
-  }
-}
-
-impl FromStr for TemplateConfig {
-  type Err = Error;
-
-  fn from_str(s: &str) -> Result<Self> {
-    Self::parse(&Path::new(s))
-  }
-}
-
-impl From<&dyn AsRef<Path>> for TemplateConfig {
-  fn from(path: &dyn AsRef<Path>) -> Self {
-    match Self::parse(path) {
-      Ok(config) => config,
-      Err(_) => TemplateConfig::default(),
-    }
   }
 }
 

--- a/src/template/parser.rs
+++ b/src/template/parser.rs
@@ -44,12 +44,12 @@ fn default_variables(
 /// }
 /// ```
 /// [`default_variables`]: fn.default_variables
-pub(crate) fn parse_template_file(
-  path: &dyn AsRef<Path>,
+pub(super) fn parse_template_file(
+  template_file: &Path,
   project_name: &str,
 ) -> Result<String> {
   // Open template file.
-  let mut file = fs::File::open(path)?;
+  let mut file = fs::File::open(template_file)?;
 
   // Read templat file to a string.
   let mut template_string = String::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::Path;
 
 /// Returns the basename of a given path. Works like Python's

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,15 +59,6 @@ pub(crate) fn filename(path: &dyn AsRef<Path>) -> &str {
   path.as_ref().file_name().and_then(|s| s.to_str()).unwrap()
 }
 
-#[inline]
-pub(crate) fn curr_dir() -> String {
-  std::env::current_dir()
-    .unwrap()
-    .to_str()
-    .unwrap()
-    .to_owned()
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;


### PR DESCRIPTION
## Feature Report

- Architectural changes
- Can use multiple templating engine: defaults are `liquid` and `handlebars`.
- Can now clone remote template into a temporary local dir
- Usage of local or remote `TemplateOptions`
- Configuration for `"template.toml"` config file in `TemplateConfig`
- `TemplateMeta` abstracts `Template` to pull together `TemplateOptions`, `ProjectInfo` & `TemplateConfig`
- Git cloning is now easier and more straight forward

## Command Line

- `project new <template-path> <project-name>`
  - `project new relative/path/../to/template my-project`
  - `project new /Absolute/path/to/template my-project`
- `project git <remote-repo> <project-name>`
  - `project git username/repo my-project`
  - `project git https://github.com/username/repo my-project`